### PR TITLE
Move cache build to task js file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10424,6 +10424,11 @@
         }
       }
     },
+    "vue-gtag": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vue-gtag/-/vue-gtag-1.6.2.tgz",
+      "integrity": "sha512-kKjVP+ch89IkGWfnszd02Lbg4W76rsPlrCZrRzDBoQaBPPx5TTQIL/bbt9hxcWDcRDNdAeh2NCYfijl/TAD+Mw=="
+    },
     "vue-hot-reload-api": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "postcss-loader": "^3.0.0",
     "sass-loader": "^7.1.0",
     "toml": "^3.0.0",
+    "vue-gtag": "^1.6.2",
     "webpack": "^4.42.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node -r esm server.js",
+    "update-cache": "node -r esm updateCacheTask.js",
     "heroku-postbuild": "webpack -p",
     "watch": "webpack --watch",
     "build": "webpack",

--- a/server.js
+++ b/server.js
@@ -17,7 +17,7 @@ const mc = memjs.Client.create(process.env.MEMCACHIER_SERVERS, {
 })
 
 // Clear on first load
-mc.delete('data.json');
+//mc.delete('data.json');
 
 // We will use Express 
 var app = express();
@@ -40,7 +40,7 @@ app.get('/api/data.json', (req, res ) => {
       console.log("retrieving new copy");
       getProjectIndex(["Brigade", "Code for America"]).then( result => {
         const cache_value = JSON.stringify(result); 
-        mc.set(k, cache_value , {expires: 360}, function(err, val){/* handle error */});
+        mc.set(k, cache_value , {expires: 360*3}, function(err, val){/* handle error */});
 
         /* // uncomment to store gzipped and bson'd - takes more memory
         const cache_value = bson.serialize({"brigades":result}); 

--- a/updateCacheTask.js
+++ b/updateCacheTask.js
@@ -14,7 +14,7 @@ const k = "data.json"
 function updateIndexCache(){
     getProjectIndex(["Brigade", "Code for America"]).then( result => {
       const cache_value = JSON.stringify(result); 
-      mc.set(k, cache_value , {expires: 360}, function(err, val){/* handle error */});
+      mc.set(k, cache_value , {expires: 360*3}, function(err, val){/* handle error */});
       console.log("setting cache")
       process.exit()
     })

--- a/updateCacheTask.js
+++ b/updateCacheTask.js
@@ -1,0 +1,23 @@
+import getProjectIndex from './api';
+import memjs from 'memjs';
+
+// We rely on memcached because github has limits API requests
+const mc = memjs.Client.create(process.env.MEMCACHIER_SERVERS, {
+    failover: true,  // default: false
+    timeout: 1,      // default: 0.5 (seconds)
+    keepAlive: true  // default: false
+})
+
+// TODO unify mc and k with server.js
+const k = "data.json"
+
+function updateIndexCache(){
+    getProjectIndex(["Brigade", "Code for America"]).then( result => {
+      const cache_value = JSON.stringify(result); 
+      mc.set(k, cache_value , {expires: 360}, function(err, val){/* handle error */});
+      console.log("setting cache")
+      process.exit()
+    })
+}
+ 
+updateIndexCache();


### PR DESCRIPTION
With increased interest, we were having periodic 'death spirals' of load where more than one person tried to hit the not-yet cached page. All incoming requests would kick off the update project process, which would consume all the memory and crash the application, and the cycle would repeat until the users went away.

Instead, I have created a task js file to (updateCacheTask.js and npm run update-cache) that builds the cache. This can be run via heroku scheduler every 10 minutes. In conjunction i boosted the cache lifespan to 15 minutes to prevent any overlaps. This should limit the work of the web worker to just serving the cached json data.

This is not the 'ideal' by any means, but more of a stop gap as we move towards a more fleshed out application structure (from quick hack for brigade congress).

This has already been deployed to Heroku (to address pressing need)