### PR TITLE
let REACT_APP_API_URL set backend

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -5,7 +5,7 @@ export function getBaseApiUrl() {
     return 'http://localhost:8080';
   }
   // TODO: WHAT SHOULD THIS RETURN?
-  return '';
+  return process.env.REACT_APP_API_URL;
 }
 
 export function filterBrigades(


### PR DESCRIPTION
Add one line setting to allow Netlify to build the front-end of the site (you need to specify a backend using environment variable.


Create Netlify account as follows:
<img width="762" alt="image" src="https://user-images.githubusercontent.com/283343/92689974-11167e80-f30e-11ea-889c-189f8a3261c3.png">
 

<img width="800" alt="image" src="https://user-images.githubusercontent.com/283343/92689845-cbf24c80-f30d-11ea-9295-0172f6d1b4f2.png">

`REACT_APP_API_URL` gets `https://thadk-cors.herokuapp.com/statusboard.brigade.cloud` which is just a CORS buster bridge to `statusboard.brigade.cloud`. I can whitelist any app's domain, just let me know. It does go to sleep though, so ideally we'll just remove the CORS limitations on our backend, if they've not already been removed.