### PR TITLE
Make search / matching case insensitive.

### DIFF
--- a/statusboard/src/components/MultiSelect/MultiSelect.js
+++ b/statusboard/src/components/MultiSelect/MultiSelect.js
@@ -70,7 +70,7 @@ export const MultiSelect = ({
                   (item) =>
                     !selectedItems.find(
                       (selectedItem) => selectedItem === item
-                    ) && item.includes(inputValue)
+                    ) && item.toLowerCase().includes(inputValue.toLowerCase())
                 )
                 .map((item) => {
                   return (


### PR DESCRIPTION
Make the tags multiselect search / match case insensitive.
This should address https://github.com/codeforamerica/brigade-project-index-statusboard/issues/68

It could still be helpful to case standardize the projects tags.