### PR TITLE
Add GitHub action for lint

### DIFF
--- a/.github/workflows/run-statusboard-lint.yml
+++ b/.github/workflows/run-statusboard-lint.yml
@@ -1,0 +1,20 @@
+name: Statusboard lint
+on:
+  push:
+    paths:
+      - 'statusboard/**'
+  pull_request:
+    paths:
+      - 'statusboard/**'
+  workflow_dispatch:
+
+jobs:
+  statusboard-lint:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: statusboard
+    steps:
+      - uses: actions/checkout@v2
+      - run: yarn --frozen-lockfile
+      - run: yarn run lint


### PR DESCRIPTION
The workflow works as is, but the eslint config doesn't until after https://github.com/codeforamerica/brigade-project-index-statusboard/pull/83.

Perhaps it is better to include it anyway -> no longer a draft.