### PR TITLE
Set `pageSize` to 50 on `/projects`

### DIFF
--- a/statusboard/src/pages/Projects/Projects.tsx
+++ b/statusboard/src/pages/Projects/Projects.tsx
@@ -73,7 +73,7 @@ function Projects(): JSX.Element {
       autoResetFilters: false,
       initialState: {
         pageIndex: 0,
-        pageSize: filteredProjects?.length || 50,
+        pageSize: 50,
         filters: initialFilterValues,
       },
       filterTypes,


### PR DESCRIPTION
It doesn't change all that much from a performance point-of-view but it does make the main page less cluttered.
An alternative could be to have a fixed-sized table instead, same as on `/brigades`. 

[Here is the link to the latest preview!](https://deploy-preview-122--dreamy-snyder-8339ae.netlify.app/?timeRange=year)

### Lighthouse before on desktop/mobile

<img width="525" alt="Skärmavbild 2021-08-20 kl  16 16 26" src="https://user-images.githubusercontent.com/2598631/130289335-ae03a5b7-cdd6-4dc6-89e7-e728b1c1f721.png">
<img width="525" alt="Skärmavbild 2021-08-20 kl  16 15 46" src="https://user-images.githubusercontent.com/2598631/130289336-11393497-fec0-4a33-bb01-d2254f21b70a.png">

### Lighthouse after on desktop/mobile
<img width="525" alt="Skärmavbild 2021-08-20 kl  16 13 01" src="https://user-images.githubusercontent.com/2598631/130289338-7b6ce942-15a7-4878-babc-2b652c4ae8fc.png">
<img width="525" alt="Skärmavbild 2021-08-20 kl  16 12 35" src="https://user-images.githubusercontent.com/2598631/130289342-ad33ad43-2d37-4be5-8442-0ad56a487e0e.png">
