### PR TITLE
issue #94, rm extra loading.. when 0 projects

### DIFF
--- a/statusboard/src/components/ProjectsTable/ProjectsTable.tsx
+++ b/statusboard/src/components/ProjectsTable/ProjectsTable.tsx
@@ -54,7 +54,7 @@ export default function ProjectsTable({
                 </td>
               </tr>
             )}
-            {!rows.length && (
+            {!rows.length &&!loading && (
               <tr>
                 <td colSpan={3}>
                   <span>No projects</span>

--- a/statusboard/src/components/ProjectsTable/ProjectsTable.tsx
+++ b/statusboard/src/components/ProjectsTable/ProjectsTable.tsx
@@ -1,11 +1,12 @@
 import { Row, useTable, TableOptions, PluginHook } from 'react-table';
-import React from 'react';
+import React, {useContext} from 'react';
 import PerfectScrollbar from 'react-perfect-scrollbar';
 import 'react-perfect-scrollbar/dist/css/styles.css';
 import Button from '../Button/Button';
 import ColumnHeader from './ColumnHeader';
 import './ProjectsTable.scss';
 import { Project } from '../../utils/types';
+import BrigadeDataContext from '../../contexts/BrigadeDataContext';
 
 export type TableAttributes = {
   options: TableOptions<Project>;
@@ -25,10 +26,10 @@ export default function ProjectsTable({
     page,
     setPageSize,
     state: { pageSize },
-    loading,
   } = useTable<Project>(options, ...plugins);
-
+  const { loading } = useContext(BrigadeDataContext);
   return (
+
     <div className="projects-table">
       <PerfectScrollbar>
         <table {...getTableProps()}>

--- a/statusboard/src/components/ProjectsTable/ProjectsTable.tsx
+++ b/statusboard/src/components/ProjectsTable/ProjectsTable.tsx
@@ -25,6 +25,7 @@ export default function ProjectsTable({
     page,
     setPageSize,
     state: { pageSize },
+    loading,
   } = useTable<Project>(options, ...plugins);
 
   return (
@@ -45,7 +46,7 @@ export default function ProjectsTable({
             ))}
           </thead>
           <tbody {...getTableBodyProps()}>
-            {!rows.length && (
+            {loading && (
               <tr>
                 <td colSpan={3}>
                   <span>Loading...</span>

--- a/statusboard/src/pages/Projects/Projects.tsx
+++ b/statusboard/src/pages/Projects/Projects.tsx
@@ -71,7 +71,6 @@ function Projects(): JSX.Element {
       columns,
       data: filteredProjects || [],
       autoResetFilters: false,
-      loading: loading,
       initialState: {
         pageIndex: 0,
         pageSize: filteredProjects?.length || 50,
@@ -90,7 +89,7 @@ function Projects(): JSX.Element {
   return (
     <>
       <h1>CfA brigade projects</h1>
-      <LoadingIndicator loading={loading}>
+      <LoadingIndicator>
         <>
           <div>
             <Select

--- a/statusboard/src/pages/Projects/Projects.tsx
+++ b/statusboard/src/pages/Projects/Projects.tsx
@@ -71,6 +71,7 @@ function Projects(): JSX.Element {
       columns,
       data: filteredProjects || [],
       autoResetFilters: false,
+      loading: loading,
       initialState: {
         pageIndex: 0,
         pageSize: filteredProjects?.length || 50,

--- a/statusboard/src/pages/Projects/Projects.tsx
+++ b/statusboard/src/pages/Projects/Projects.tsx
@@ -89,7 +89,7 @@ function Projects(): JSX.Element {
   return (
     <>
       <h1>CfA brigade projects</h1>
-      <LoadingIndicator>
+      <LoadingIndicator loading={loading}>
         <>
           <div>
             <Select


### PR DESCRIPTION
Hi from a newbie! Saw this issue and I think I was able to fix it. Basically, ProjectsTable was using rows.length as a conditional for rendering loading, rather than looking for a loading state. HTH