### PR TITLE
fixes issue #128, long text not wrapping on /brigades or /projects

### DIFF
--- a/statusboard/src/components/ProjectsTable/ColumnHeader.scss
+++ b/statusboard/src/components/ProjectsTable/ColumnHeader.scss
@@ -11,6 +11,11 @@
     margin-left: 1rem;
   }
 
+  input {
+    width:100%;
+    box-sizing: content-box;
+  }
+
   .sort-button {
     height: 100%;
     width: 2rem;

--- a/statusboard/src/components/ProjectsTable/ProjectsTable.scss
+++ b/statusboard/src/components/ProjectsTable/ProjectsTable.scss
@@ -20,8 +20,9 @@
     table-layout:fixed;
   }
 
-  a {
-  }
+  th:nth-of-type(2){
+    width:40%;
+  } 
 
   th {
     background-color: var(--cfa-purple-dark);

--- a/statusboard/src/components/ProjectsTable/ProjectsTable.scss
+++ b/statusboard/src/components/ProjectsTable/ProjectsTable.scss
@@ -1,6 +1,7 @@
 .projects-table {
   width: 100%;
   height: auto;
+  
 
   // Make top scrollbar show rather than bottom
   .ps__rail-x {
@@ -16,10 +17,10 @@
     width: 100%;
     border-spacing: 0;
     border-radius: inherit;
+    table-layout:fixed;
   }
 
   a {
-    word-break: break-all;
   }
 
   th {
@@ -34,6 +35,7 @@
   td {
     padding: 0.5rem;
     font-size: 1rem;
+    overflow-wrap: break-word;
   }
 
   tr:nth-child(odd) {


### PR DESCRIPTION
Hi, this CSS fix should fix text wrapping on both `/brigades` and `/projects` as described in #128 

With all text wrapping, react-table defaults to table columns being equally wide, and the only way to set column widths appears to be using hardcoded pixel values (no percentages or flex-basis). That didn't look very good, so I also added a selector to target the "description" column and make it 40% of the table, which makes the other 3 columns share the remaining 60% equally. All this to say I'm totally happy if you wish to change the width of the description column to larger or smaller, but 40% looked fairly pleasing to my eye on a variety of monitor sizes.