### PR TITLE
Responsive table

### DIFF
--- a/statusboard/src/components/ProjectsTable/ProjectsTable.tsx
+++ b/statusboard/src/components/ProjectsTable/ProjectsTable.tsx
@@ -1,7 +1,9 @@
 import { Row, useTable, TableOptions, PluginHook } from 'react-table';
 import React, { useContext, useEffect } from 'react';
-import PerfectScrollbar from 'react-perfect-scrollbar';
 import 'react-perfect-scrollbar/dist/css/styles.css';
+import { Table, Thead, Tbody, Tr, Th, Td } from 'react-super-responsive-table';
+import './SuperResponsiveTableStyle.css'
+import PerfectScrollbar from 'react-perfect-scrollbar';
 import Button from '../Button/Button';
 import ColumnHeader from './ColumnHeader';
 import './ProjectsTable.scss';
@@ -40,10 +42,10 @@ export default function ProjectsTable({
 
     <div className="projects-table">
       <PerfectScrollbar>
-        <table {...getTableProps()}>
+        <Table {...getTableProps()}>
           <thead>
             {headerGroups.map((headerGroup) => (
-              <tr {...headerGroup.getHeaderGroupProps()}>
+              <Tr {...headerGroup.getHeaderGroupProps()}>
                 {headerGroup.headers.map((column) => (
                   <ColumnHeader
                     column={column}
@@ -51,36 +53,36 @@ export default function ProjectsTable({
                     disableSort={!rows.length}
                   />
                 ))}
-              </tr>
+              </Tr>
             ))}
           </thead>
-          <tbody {...getTableBodyProps()}>
+          <Tbody {...getTableBodyProps()}>
             {loading && (
-              <tr>
-                <td colSpan={3}>
+              <Tr>
+                <Td colSpan={3}>
                   <span>Loading...</span>
-                </td>
-              </tr>
+                </Td>
+              </Tr>
             )}
             {!rows.length && !loading && (
-              <tr>
-                <td colSpan={3}>
+              <Tr>
+                <Td colSpan={3}>
                   <span>No projects</span>
-                </td>
-              </tr>
+                </Td>
+              </Tr>
             )}
             {page.map((row: Row<Project>) => {
               prepareRow(row);
               return (
-                <tr {...row.getRowProps()}>
+                <Tr {...row.getRowProps()}>
                   {row.cells.map((cell) => (
-                    <td {...cell.getCellProps()}>{cell.render('Cell')}</td>
+                    <Td {...cell.getCellProps()} style={{paddingLeft:'0.5rem !important'}}>{cell.render('Cell')}</Td>
                   ))}
-                </tr>
+                </Tr>
               );
             })}
-          </tbody>
-        </table>
+          </Tbody>
+        </Table>
         {pageSize < rows.length && (
           <div className="load-projects-button">
             {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}

--- a/statusboard/src/components/ProjectsTable/ProjectsTable.tsx
+++ b/statusboard/src/components/ProjectsTable/ProjectsTable.tsx
@@ -38,12 +38,13 @@ export default function ProjectsTable({
     setRowCounter?.(rows.length);
   }, [rows, setRowCounter]);
 
+
   return (
 
     <div className="projects-table">
       <PerfectScrollbar>
         <Table {...getTableProps()}>
-          <thead>
+          <thead className="desktop">
             {headerGroups.map((headerGroup) => (
               <Tr {...headerGroup.getHeaderGroupProps()}>
                 {headerGroup.headers.map((column) => (
@@ -56,6 +57,7 @@ export default function ProjectsTable({
               </Tr>
             ))}
           </thead>
+    
           <Tbody {...getTableBodyProps()}>
             {loading && (
               <Tr>

--- a/statusboard/src/components/ProjectsTable/SuperResponsiveTableStyle.css
+++ b/statusboard/src/components/ProjectsTable/SuperResponsiveTableStyle.css
@@ -1,0 +1,66 @@
+/* inspired by: https://css-tricks.com/responsive-data-tables/ */
+.responsiveTable {
+  width: 100%;
+}
+
+.responsiveTable td .tdBefore {
+  display: none;
+}
+
+@media screen and (max-width: 40em) {
+  /*
+    Force table elements to not behave like tables anymore
+    Hide table headers (but not display: none;, for accessibility)
+  */
+
+  .responsiveTable table,
+  .responsiveTable thead,
+  .responsiveTable tbody,
+  .responsiveTable th,
+  .responsiveTable td,
+  .responsiveTable tr {
+    display: block;
+  }
+
+  .responsiveTable thead tr {
+    position: absolute;
+    top: -9999px;
+    left: -9999px;
+    border-bottom: 2px solid #333;
+  }
+
+  .responsiveTable tbody tr {
+    border: 1px solid #000;
+    padding: .25em;
+  }
+
+  .responsiveTable td.pivoted {
+    /* Behave like a "row" */
+    border: none !important;
+    position: relative;
+    /* padding-left: calc(50% + 10px) !important; */
+    text-align: left !important;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+  }
+
+  .responsiveTable td.pivoted:nth-child(1) {
+    font-weight:bold;
+    font-size: large;
+
+  }
+
+  .responsiveTable td .tdBefore {
+    /* Now like a table header */
+    position: absolute;
+    display: block;
+
+    /* Top/left values mimic padding */
+    left: 1rem;
+    width: calc(50% - 20px);
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    text-align: left !important;
+    font-weight: 600;
+  }
+}

--- a/statusboard/src/components/ProjectsTable/SuperResponsiveTableStyle.css
+++ b/statusboard/src/components/ProjectsTable/SuperResponsiveTableStyle.css
@@ -7,7 +7,26 @@
   display: none;
 }
 
-@media screen and (max-width: 40em) {
+.mobile {
+  display:none;
+}
+
+.mobileheader {
+  display:none;
+}
+
+@media screen and (max-width: 775px) {
+  .desktop {
+    display:none;
+  }
+  .mobile {
+    display:block;
+  }
+
+  .mobileheader {
+    display:block;
+  }
+
   /*
     Force table elements to not behave like tables anymore
     Hide table headers (but not display: none;, for accessibility)

--- a/statusboard/src/pages/Projects/Projects.scss
+++ b/statusboard/src/pages/Projects/Projects.scss
@@ -1,0 +1,8 @@
+.mobileheader {
+    background-color: var(--cfa-purple-dark);
+    color: var(--cfa-white);
+    padding: 0.25rem 0rem 0.5rem 0rem;
+    text-align: left;
+    font-size: 1rem;
+    min-width: 12rem;
+  }

--- a/statusboard/src/pages/Projects/Projects.tsx
+++ b/statusboard/src/pages/Projects/Projects.tsx
@@ -20,16 +20,19 @@ import { useProjectFilters } from '../../utils/useProjectFilters';
 import { Project } from '../../utils/types';
 import getTableColumns from './utils';
 import queryParamFilter from '../../components/ProjectsTable/QueryParamFilter';
+import './Projects.scss'
 
 function Projects(): JSX.Element {
   const { allTopics, loading } = useContext(BrigadeDataContext);
   const [rowCounter, setRowCounter] = useState(0);
+  const [searchTerm,setSearchTerm] = useState("");
 
   const {
     topics,
     timeRange,
     setFilters,
     projectsFilteredByTime,
+    projectsFilteredByText,
     projectsFilteredByAllParams: filteredProjects,
     queryParameters,
   } = useProjectFilters();
@@ -128,6 +131,16 @@ function Projects(): JSX.Element {
             />
           )}
           <br />
+  
+          <div className="text-input form-control-container mobileheader">
+            <label htmlFor="search">Search projects</label>
+            <input type="text" className="form-control" value={searchTerm} 
+            name="searchTerm" onChange={(e: ChangeEvent<HTMLInputElement>) =>{
+              setFilters({ searchTerm: String(e.target.value) });
+              setSearchTerm(e.target.value);}
+              }/>
+            </div>
+          
           <ProjectsTable
             options={options}
             plugins={hooks}

--- a/statusboard/src/utils/useProjectFilters.ts
+++ b/statusboard/src/utils/useProjectFilters.ts
@@ -10,6 +10,7 @@ import {
   filterProjectsByTime,
   filterProjectsByTopics,
   filterProjectsByCfA,
+  filterProjectsByText,
 } from './utils';
 
 export type Filter = {
@@ -17,6 +18,7 @@ export type Filter = {
   timeRange?: string;
   brigades?: string[];
   nonCfA?: string;
+  searchTerm?: string;
 };
 
 export type ProjectFilterReturn = Filter & {
@@ -25,6 +27,7 @@ export type ProjectFilterReturn = Filter & {
   projectsFilteredByBrigades: Project[];
   projectsFilteredByAllParams: Project[];
   projectsFilteredByCfA: Project[];
+  projectsFilteredByText: Project[];
   setFilters: (filter: Filter, preserveFilters?: boolean) => void;
   queryParameters: ParsedQuery;
 };
@@ -36,16 +39,19 @@ export const useProjectFilters = (): ProjectFilterReturn => {
   const queryParameters = parse(search, {
     arrayFormat: 'comma',
   });
+  
   const {
     topics: _topics,
     timeRange,
     brigades,
-    nonCfA
+    nonCfA,
+    searchTerm,
   } = (queryParameters || {}) as {
     topics: string[];
     timeRange: ActiveThresholdsKeys;
     brigades: string[];
     nonCfA: string;
+    searchTerm: string;
   };
 
   let topics = _topics;
@@ -69,8 +75,8 @@ export const useProjectFilters = (): ProjectFilterReturn => {
   );
 
   const projectsFilteredByAllParams = useMemo<Project[]>(
-    () => filterActiveProjects({ topics, timeRange, brigades, nonCfA}, allProjects),
-    [topics, timeRange, brigades, nonCfA, allProjects],
+    () => filterActiveProjects({ topics, timeRange, brigades, nonCfA, searchTerm}, allProjects),
+    [topics, timeRange, brigades, nonCfA, searchTerm, allProjects],
   );
 
   const projectsFilteredByCfA = useMemo<Project[]>(
@@ -78,6 +84,11 @@ export const useProjectFilters = (): ProjectFilterReturn => {
     [nonCfA, allProjects],
   );
   
+  const projectsFilteredByText = useMemo<Project[]>(
+    () => filterProjectsByText(allProjects || [], searchTerm),
+    [searchTerm, allProjects],
+  );
+
   const history = useHistory();
   const setFilters = (newFilter: Filter, preserveFilters = true) => {
     let _newFilter = newFilter;
@@ -105,6 +116,7 @@ export const useProjectFilters = (): ProjectFilterReturn => {
     projectsFilteredByCfA,
     projectsFilteredByTopics,
     projectsFilteredByBrigades,
+    projectsFilteredByText,
     projectsFilteredByAllParams,
   };
 };

--- a/statusboard/src/utils/utils.ts
+++ b/statusboard/src/utils/utils.ts
@@ -112,15 +112,26 @@ export function filterProjectsByCfA(
   nonCfA?: string
 ) {
   if (nonCfA === 'true') {
-    console.log("returning all projects");
+    
     console.log(projects.length);
     return projects;
   }
-  console.log("filter only cfa projects");
+  
   return projects.filter((p: Project) =>
     p?.brigade?.type ? p.brigade.type.includes("Brigade") || p.brigade.type.includes("Code for America") : false
   );
+}
 
+export function filterProjectsByText(
+  projects: Project[],
+  text?: string
+){
+if (!text){
+return projects;
+}
+return projects.filter((p:Project)=>
+p?.description?.includes(text) || p?.brigade?.type?.includes(text) || p?.name?.includes(text)
+)
 }
 
 export function filterActiveProjects(
@@ -129,12 +140,13 @@ export function filterActiveProjects(
     topics?: string[];
     brigades?: string[];
     nonCfA: string;
+    searchTerm?: string;
   },
   projects?: Project[]
 ) {
   if (!projects) return [];
   // Set destructuring and allow defaults to be overwritten
-  const { timeRange, topics, brigades, nonCfA } = options || {};
+  const { timeRange, topics, brigades, nonCfA, searchTerm } = options || {};
   let newProjects: ProjectWithTopicsMatched[] = filterProjectsByBrigades(
     projects,
     brigades
@@ -142,6 +154,7 @@ export function filterActiveProjects(
   newProjects = filterProjectsByTopics(newProjects, topics);
   newProjects = filterProjectsByTime(newProjects, timeRange);
   newProjects = filterProjectsByCfA(newProjects, nonCfA);
+  newProjects = filterProjectsByText(newProjects,searchTerm);
   return newProjects;
 }
 


### PR DESCRIPTION
Please consider this a possibility for making the statusboard work on smaller screens.

This uses the react-super-responsive-table library, with some tweaks to the CSS to make the breakpoint break earlier and a few other changes.

Because the existing column filtering is built into react-table, we can't make the existing table header responsive, so I created a different text filter that works similar to the existing filters that use the URL query string.

Now that I've done this I wonder if we would also consider removing the per-column filters on large screens, because the more I think about it, the more I struggle to imagine a use case where someone would only want to filter by one column? (For example, if I want to see "police" projects I don't care if the description or project name has police in it, I'm probably interested if there's a match in either column.)

Just a thought!