### PR TITLE
Remove GITHUB_TOKEN

### DIFF
--- a/api/src/api.js
+++ b/api/src/api.js
@@ -131,7 +131,7 @@ export async function getTaxonomy() {
   try {
     // Getting the Github repository
     const octokit = new Octokit({
-      auth: process.env.GITHUB_TOKEN,
+      // auth: process.env.GITHUB_TOKEN,
     });
     // return promise the resolves once we have unzipped and merged
     // all the data


### PR DESCRIPTION
We should only be sending a few requests/day to GitHub -> we don't need a token. PR is because for some reason the current GitHub token expired.