### PR TITLE
Add basic error handling on taxonomy API timeout

### DIFF
--- a/statusboard/src/contexts/TaxonomyDataContext.tsx
+++ b/statusboard/src/contexts/TaxonomyDataContext.tsx
@@ -37,31 +37,31 @@ const TaxonomyDataContextProvider = ({
     const getData = async () => {
 
       try {
-      const issues_resp = await axios.get(`https://api.taxonomy.sandbox.k8s.brigade.cloud/taxonomy?category=Issues`)
-      const issues = issues_resp.data;
-          // only take the children of the first object, this is the detailed list of taxonomy items
+        const issues_resp = await axios.get(`https://api.taxonomy.sandbox.k8s.brigade.cloud/taxonomy?category=Issues`)
+        const issues = issues_resp.data;
+        // only take the children of the first object, this is the detailed list of taxonomy items
 
-      const taxonomyIssues:TaxonomyList = issues[0].children;
-      const issuesMapLocal = new Map<string, string[]>(taxonomyIssues.map(key => [key.text, key.children]));
-      setIssuesMap(issuesMapLocal);
+        const taxonomyIssues: TaxonomyList = issues[0].children;
+        const issuesMapLocal = new Map<string, string[]>(taxonomyIssues.map(key => [key.text, key.children]));
+        setIssuesMap(issuesMapLocal);
       }
-      catch(error){
-       setIsTaxonomyError(true);
+      catch (error) {
+        setIsTaxonomyError(true);
       };
-     
-     try {
-      const paa_resp = await axios.get(`https://api.taxonomy.sandbox.k8s.brigade.cloud/taxonomy?category=Priority-Action-Areas`);
-      const _paa_data = paa_resp.data
-      const priorityAreas = _paa_data;
 
-      // only take the children of the first object, this is the detailed list of taxonomy items
-      const taxonomyPriorityAreas:TaxonomyList = priorityAreas[0].children;
-      const priorityAreasMapLocal = new Map<string, string[]>(taxonomyPriorityAreas.map(key => [key.text, key.children]));
-      setPriorityAreasMap(priorityAreasMapLocal);
-     }
-     catch(error){
-       setIsTaxonomyError(true);
-     }
+      try {
+        const paa_resp = await axios.get(`https://api.taxonomy.sandbox.k8s.brigade.cloud/taxonomy?category=Priority-Action-Areas`);
+        const _paa_data = paa_resp.data
+        const priorityAreas = _paa_data;
+
+        // only take the children of the first object, this is the detailed list of taxonomy items
+        const taxonomyPriorityAreas: TaxonomyList = priorityAreas[0].children;
+        const priorityAreasMapLocal = new Map<string, string[]>(taxonomyPriorityAreas.map(key => [key.text, key.children]));
+        setPriorityAreasMap(priorityAreasMapLocal);
+      }
+      catch (error) {
+        setIsTaxonomyError(true);
+      }
     }
     getData();
     // Disabling bc data length isn't going to change outside of this hook

--- a/statusboard/src/contexts/TaxonomyDataContext.tsx
+++ b/statusboard/src/contexts/TaxonomyDataContext.tsx
@@ -13,13 +13,13 @@ type TaxonomyList = TaxonomyItem[];
 type TaxonomyDataContextType = {
   issuesMap: Map<string, string[]>;
   priorityAreasMap: Map<string, string[]>;
-  isError: boolean;
+  isTaxonomyError: boolean;
 };
 
 const TaxonomyDataContext = createContext<TaxonomyDataContextType>({
   issuesMap: new Map<string, string[]>(),
   priorityAreasMap: new Map<string, string[]>(),
-  isError: false
+  isTaxonomyError: false
 });
 
 const { Provider, Consumer } = TaxonomyDataContext;
@@ -31,7 +31,7 @@ const TaxonomyDataContextProvider = ({
 }) => {
   const [issuesMap, setIssuesMap] = useState<Map<string, string[]>>(new Map());
   const [priorityAreasMap, setPriorityAreasMap] = useState<Map<string, string[]>>(new Map());
-  const [isError, setIsError] = useState(false);
+  const [isTaxonomyError, setIsTaxonomyError] = useState(false);
 
   useEffect(() => {
     const getData = async () => {
@@ -46,7 +46,7 @@ const TaxonomyDataContextProvider = ({
       setIssuesMap(issuesMapLocal);
       }
       catch(error){
-       setIsError(true);
+       setIsTaxonomyError(true);
       };
      
      try {
@@ -60,7 +60,7 @@ const TaxonomyDataContextProvider = ({
       setPriorityAreasMap(priorityAreasMapLocal);
      }
      catch(error){
-       setIsError(true);
+       setIsTaxonomyError(true);
      }
     }
     getData();
@@ -74,7 +74,7 @@ const TaxonomyDataContextProvider = ({
       value={{
         issuesMap: issuesMap,
         priorityAreasMap: priorityAreasMap,
-        isError: isError
+        isTaxonomyError: isTaxonomyError
       }}
     >
       {childNodes}

--- a/statusboard/src/pages/Projects/Projects.tsx
+++ b/statusboard/src/pages/Projects/Projects.tsx
@@ -38,7 +38,7 @@ function Projects(): JSX.Element {
   const { allTopics, loading } = useContext(BrigadeDataContext);
   const [rowCounter, setRowCounter] = useState(0);
 
-  const { priorityAreasMap, issuesMap } = useContext(TaxonomyDataContext);
+  const { priorityAreasMap, issuesMap, isError } = useContext(TaxonomyDataContext);
 
   const {
     topics,
@@ -210,6 +210,7 @@ function Projects(): JSX.Element {
                 setFilters({ nonCfA: String(e.target.checked) })
               }
             />
+            {!isError &&
             <div style={{ display: 'flex', gap: '30px', marginTop: '10px' }}>
               <Select
                 extraRef={issueSelect}
@@ -243,10 +244,10 @@ function Projects(): JSX.Element {
                   clearIssueSelect();
                 }}
               />
-            </div>
+            </div>}
           </div>
           <br />
-          {availableTopics && (
+          {availableTopics  && (
             <MultiSelect
               clearTaxonomy={clearTaxonomy}
               selectedItems={topics}

--- a/statusboard/src/pages/Projects/Projects.tsx
+++ b/statusboard/src/pages/Projects/Projects.tsx
@@ -38,7 +38,7 @@ function Projects(): JSX.Element {
   const { allTopics, loading } = useContext(BrigadeDataContext);
   const [rowCounter, setRowCounter] = useState(0);
 
-  const { priorityAreasMap, issuesMap, isError } = useContext(TaxonomyDataContext);
+  const { priorityAreasMap, issuesMap, isTaxonomyError } = useContext(TaxonomyDataContext);
 
   const {
     topics,
@@ -210,7 +210,7 @@ function Projects(): JSX.Element {
                 setFilters({ nonCfA: String(e.target.checked) })
               }
             />
-            {!isError &&
+            {!isTaxonomyError &&
             <div style={{ display: 'flex', gap: '30px', marginTop: '10px' }}>
               <Select
                 extraRef={issueSelect}


### PR DESCRIPTION
Per @giosce 's suggestion, on an error from the taxonomy API, the functionality to search by issue or priority area is hidden. A future PR could tweak how the errors are handled.