### PR TITLE
fix table header with addition of new columns

### DIFF
--- a/statusboard/src/components/ProjectsTable/ColumnHeader.scss
+++ b/statusboard/src/components/ProjectsTable/ColumnHeader.scss
@@ -52,7 +52,7 @@
 }
 
 
-.hideThirdAndFourthColumns {
+.hideFifthColumn {
   .sort-button {
     margin:0.5em;
     width: 1rem;

--- a/statusboard/src/pages/Projects/Projects.scss
+++ b/statusboard/src/pages/Projects/Projects.scss
@@ -2,11 +2,8 @@
   th{
       width:calc(100% - 0.5em) !important;
   }
-  .hideThirdAndFourthColumns {
-    th:nth-of-type(3){
-      display:none;
-    }
-    th:nth-of-type(4){
+  .hideFifthColumn {
+    th:nth-of-type(5){
       display:none;
     }
   }

--- a/statusboard/src/pages/Projects/Projects.tsx
+++ b/statusboard/src/pages/Projects/Projects.tsx
@@ -261,7 +261,7 @@ function Projects(): JSX.Element {
             />
           )}
           <br />
-          <div className="hideThirdAndFourthColumns">
+          <div className="hideFifthColumn">
             <ProjectsTable
               options={options}
               plugins={hooks}


### PR DESCRIPTION
With the new columns added, the CSS to hide non-sortable columns broke. This PR fixes that.

I hate how brittle this solution is but can't think of a way around it.