### PR TITLE
Remove Taxonomy empty items.

### DIFF
--- a/statusboard/src/contexts/TaxonomyDataContext.tsx
+++ b/statusboard/src/contexts/TaxonomyDataContext.tsx
@@ -42,7 +42,8 @@ const TaxonomyDataContextProvider = ({
         // only take the children of the first object, this is the detailed list of taxonomy items
 
         const taxonomyIssues: TaxonomyList = issues[0].children;
-        const issuesMapLocal = new Map<string, string[]>(taxonomyIssues.map(key => [key.text, key.children]));
+        const issuesMapLocal = new Map<string, string[]>
+          (taxonomyIssues.filter(key => key.children).map(key => [key.text, key.children]));
         setIssuesMap(issuesMapLocal);
       }
       catch (error) {
@@ -56,7 +57,8 @@ const TaxonomyDataContextProvider = ({
 
         // only take the children of the first object, this is the detailed list of taxonomy items
         const taxonomyPriorityAreas: TaxonomyList = priorityAreas[0].children;
-        const priorityAreasMapLocal = new Map<string, string[]>(taxonomyPriorityAreas.map(key => [key.text, key.children]));
+        const priorityAreasMapLocal = new Map<string, string[]>
+          (taxonomyPriorityAreas.filter(key => key.children).map(key => [key.text, key.children]));
         setPriorityAreasMap(priorityAreasMapLocal);
       }
       catch (error) {


### PR DESCRIPTION
Addressing issue #194.
It can be tested verifying that "Civic Infrastructure", "National Security" and another couple of "empty" items (you can see them in Taxonomy->Issues) don't show up in Statusboard "Issues" dropdown.