### PR TITLE
Fix sorting on brigades (map) page AND get user location

### DIFF
--- a/statusboard/src/components/Map/Map.js
+++ b/statusboard/src/components/Map/Map.js
@@ -27,7 +27,7 @@ export default function Map({ brigadeData, filterOpts, setFilterOpts }) {
       const { latitude, longitude } = filterOpts.selectedBrigade || {};
       setCenter([latitude, longitude]);
     } else {
-      let userCenter = [];
+      const userCenter = [];
       const foundLocation = (position) => {
         userCenter = [position.coords.latitude, position.coords.longitude];
         setZoom(2);
@@ -38,7 +38,7 @@ export default function Map({ brigadeData, filterOpts, setFilterOpts }) {
         setCenter(defaultCenter);
       };
 
-      const options = { timeOut: 20000, maximumAge: 60 * 60 * 24 };
+      const options = { timeOut: 20000, maximumAge: 60 * 60 * 24 * 1000 };
 
       navigator.geolocation.getCurrentPosition(
         foundLocation,
@@ -52,7 +52,6 @@ export default function Map({ brigadeData, filterOpts, setFilterOpts }) {
 
   return (
     <div className="map leaflet-container">
-      {}
       <LeafletMap
         // TODO: WHY IS FOCUS STYLING NOT WORKING ON ZOOM BUTTONS??
         zoom={zoom}

--- a/statusboard/src/components/Map/Map.js
+++ b/statusboard/src/components/Map/Map.js
@@ -14,8 +14,10 @@ import './Map.scss';
 export default function Map({ brigadeData, filterOpts, setFilterOpts }) {
   const defaultZoom = 2;
   const defaultCenter = [44.967243, -104.771556];
+
   const [zoom, setZoom] = useState(defaultZoom);
   const [center, setCenter] = useState(defaultCenter);
+
   const { name: selectedBrigadeName } = filterOpts.selectedBrigade || {};
 
   useEffect(() => {
@@ -25,14 +27,32 @@ export default function Map({ brigadeData, filterOpts, setFilterOpts }) {
       const { latitude, longitude } = filterOpts.selectedBrigade || {};
       setCenter([latitude, longitude]);
     } else {
-      setZoom(defaultZoom);
-      setCenter(defaultCenter);
+      let userCenter = [];
+      const foundLocation = (position) => {
+        userCenter = [position.coords.latitude, position.coords.longitude];
+        setZoom(2);
+        setCenter(userCenter);
+      };
+      const noLocation = () => {
+        setZoom(defaultZoom);
+        setCenter(defaultCenter);
+      };
+
+      const options = { timeOut: 20000, maximumAge: 60 * 60 * 24 };
+
+      navigator.geolocation.getCurrentPosition(
+        foundLocation,
+        noLocation,
+        options
+      );
     }
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedBrigadeName]);
 
   return (
     <div className="map leaflet-container">
+      {}
       <LeafletMap
         // TODO: WHY IS FOCUS STYLING NOT WORKING ON ZOOM BUTTONS??
         zoom={zoom}

--- a/statusboard/src/components/Map/Map.js
+++ b/statusboard/src/components/Map/Map.js
@@ -27,7 +27,7 @@ export default function Map({ brigadeData, filterOpts, setFilterOpts }) {
       const { latitude, longitude } = filterOpts.selectedBrigade || {};
       setCenter([latitude, longitude]);
     } else {
-      const userCenter = [];
+      let userCenter = [];
       const foundLocation = (position) => {
         userCenter = [position.coords.latitude, position.coords.longitude];
         setZoom(2);

--- a/statusboard/src/pages/Brigades/Brigades.js
+++ b/statusboard/src/pages/Brigades/Brigades.js
@@ -1,7 +1,12 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { usePagination, useSortBy } from 'react-table';
 import Map from '../../components/Map/Map';
-import { getProjectsFromBrigadeData, filterBrigades } from '../../utils/utils';
+import {
+  getProjectsFromBrigadeData,
+  filterBrigades,
+  customStringSort,
+  lastPushSort,
+} from '../../utils/utils';
 import BrigadeDataContext from '../../contexts/BrigadeDataContext';
 import { ProjectsTable, Select } from '../../components';
 import './Brigades.scss';
@@ -14,23 +19,47 @@ function Brigades() {
   const { selectedBrigade } = filterOpts; // also has bounds
   const [projects, setProjects] = useState(allProjects);
 
+  const ProjectCell = (cell) => {
+    const project = cell.row.original;
+    return <a href={project.code_url}>{project.name}</a>;
+  };
+
+  const BrigadeCell = (cell) => {
+    const project = cell.row.original;
+    return (
+      <a target="new" href={project.brigade.website}>
+        {project.brigade.name}
+      </a>
+    );
+  };
+
   const columns = React.useMemo(
     () => [
       {
         Header: 'Project name',
-        accessor: (project) => <a href={project.code_url}>{project.name}</a>,
+        accessor: 'name',
+        sortType: 'customStringSort',
+        Cell: ProjectCell,
       },
       {
         Header: 'Description',
         accessor: 'description',
+        sortType: 'customStringSort',
       },
       {
         Header: 'Brigade',
-		accessor: (project) => <a target="new" href={project.brigade.website}>{project.brigade.name}</a>,
+        accessor: 'brigade',
+        sortType: 'customStringSort',
+        Cell: BrigadeCell,
       },
     ],
-    [],
+    []
   );
+
+  const sortTypes = {
+    customStringSort,
+    lastPushSort,
+  };
 
   useEffect(() => {
     const newlyFilteredBrigadeData = filterBrigades(allBrigadeData, filterOpts);
@@ -48,7 +77,7 @@ function Brigades() {
       brigadesShowingString = `${brigadesShowingString} ${selectedBrigade.name}`;
     } else {
       brigadesShowingString = `${brigadesShowingString} ${firstFiveBrigades.join(
-        ', ',
+        ', '
       )}`;
     }
     if (filteredBrigadeData.length > 5) {
@@ -61,7 +90,16 @@ function Brigades() {
   const options = {
     columns,
     data: projects || [],
-    initialState: { pageIndex: 0, pageSize: 50 },
+    initialState: {
+      pageIndex: 0,
+      pageSize: 50,
+      sortBy: [
+        {
+          id: 'name',
+        },
+      ],
+    },
+    sortTypes,
   };
   const plugins = [useSortBy, usePagination];
 

--- a/statusboard/src/pages/Brigades/Brigades.js
+++ b/statusboard/src/pages/Brigades/Brigades.js
@@ -5,7 +5,6 @@ import {
   getProjectsFromBrigadeData,
   filterBrigades,
   customStringSort,
-  lastPushSort,
 } from '../../utils/utils';
 import BrigadeDataContext from '../../contexts/BrigadeDataContext';
 import { ProjectsTable, Select } from '../../components';
@@ -58,7 +57,6 @@ function Brigades() {
 
   const sortTypes = {
     customStringSort,
-    lastPushSort,
   };
 
   useEffect(() => {

--- a/statusboard/src/pages/Projects/Projects.tsx
+++ b/statusboard/src/pages/Projects/Projects.tsx
@@ -15,13 +15,10 @@ import {
   FilterTypes,
   Filters,
   useSortBy,
-  SortByFn,
-  Row,
-  IdType,
 } from 'react-table';
 import { fuzzyTextFilter } from '../../components';
 import ProjectsTable from '../../components/ProjectsTable/ProjectsTable';
-import { ACTIVE_THRESHOLDS, getTopicsFromProjects } from '../../utils/utils';
+import { ACTIVE_THRESHOLDS, getTopicsFromProjects, customStringSort } from '../../utils/utils';
 import Select from '../../components/Select/Select';
 import Checkbox from '../../components/Checkbox/Checkbox';
 import { MultiSelect } from '../../components/MultiSelect/MultiSelect';
@@ -33,6 +30,7 @@ import getTableColumns from './utils';
 import queryParamFilter from '../../components/ProjectsTable/QueryParamFilter';
 import TaxonomyDataContext from '../../contexts/TaxonomyDataContext';
 import './Projects.scss';
+
 
 function Projects(): JSX.Element {
   const { allTopics, loading } = useContext(BrigadeDataContext);
@@ -60,58 +58,11 @@ function Projects(): JSX.Element {
     []
   );
 
-  const customStringSort: SortByFn<Project> = (
-    rowA: Row<Project>,
-    rowB: Row<Project>,
-    id: IdType<Project>,
-    desc?: boolean
-  ): number => {
-    const rowAValue: string = rowA.values[id] ?? '';
-    const rowBValue: string = rowB.values[id] ?? '';
-
-    const valueA: string = String(rowAValue).toLowerCase();
-    const valueB: string = String(rowBValue).toLowerCase();
-    if (desc) {
-      return valueA.localeCompare(valueB) > 0 ? 1 : -1;
-    }
-    return valueB.localeCompare(valueA) > 0 ? -1 : 1;
-  };
-
-  function periodToNumber(period: string) {
-    if (period === 'week') {
-      return 0;
-    }
-    if (period === 'month') {
-      return 1;
-    }
-    if (period === 'year') {
-      return 2;
-    }
-    if (period === 'over_a_year') {
-      return 3;
-    }
-    return 99;
-  }
-
-  const lastPushSort: SortByFn<Project> = (
-    rowA: Row<Project>,
-    rowB: Row<Project>,
-    id: IdType<Project>,
-    desc?: boolean
-  ): number => {
-    // need to convert week, month to 1, 2, ..
-    const d1: number = periodToNumber(rowA.values[id]);
-    const d2: number = periodToNumber(rowB.values[id]);
-    if (desc) {
-      return d1 - d2 > 0 ? 1 : -1;
-    }
-    return d2 - d1 > 0 ? -1 : 1;
-  };
-
-  const sortTypes: Record<string, SortByFn<Project>> = {
+  const sortTypes = {
     customStringSort,
-    lastPushSort,
   };
+
+
 
   const columns: Column<Project>[] = useMemo(
     () => getTableColumns(topics, setFilters),

--- a/statusboard/src/pages/Projects/Projects.tsx
+++ b/statusboard/src/pages/Projects/Projects.tsx
@@ -18,7 +18,7 @@ import {
 } from 'react-table';
 import { fuzzyTextFilter } from '../../components';
 import ProjectsTable from '../../components/ProjectsTable/ProjectsTable';
-import { ACTIVE_THRESHOLDS, getTopicsFromProjects, customStringSort } from '../../utils/utils';
+import { ACTIVE_THRESHOLDS, getTopicsFromProjects, customStringSort, lastPushSort } from '../../utils/utils';
 import Select from '../../components/Select/Select';
 import Checkbox from '../../components/Checkbox/Checkbox';
 import { MultiSelect } from '../../components/MultiSelect/MultiSelect';
@@ -60,6 +60,7 @@ function Projects(): JSX.Element {
 
   const sortTypes = {
     customStringSort,
+    lastPushSort
   };
 
 

--- a/statusboard/src/utils/types.ts
+++ b/statusboard/src/utils/types.ts
@@ -1,4 +1,8 @@
 // If we also use typescript on the back end, we can move this into a "common" folder (still within the front end bc CRA is opinionated) and use it there too
+import { SortByFn,
+  Row,
+  IdType, } from "react-table";
+import { customStringSort,lastPushSort } from "./utils";
 
 export type Brigade = {
   name: string;
@@ -41,3 +45,6 @@ export type Location = {
     longitude?: string | number;
   };
 };
+
+
+

--- a/statusboard/src/utils/types.ts
+++ b/statusboard/src/utils/types.ts
@@ -1,8 +1,4 @@
 // If we also use typescript on the back end, we can move this into a "common" folder (still within the front end bc CRA is opinionated) and use it there too
-import { SortByFn,
-  Row,
-  IdType, } from "react-table";
-import { customStringSort,lastPushSort } from "./utils";
 
 export type Brigade = {
   name: string;
@@ -45,6 +41,3 @@ export type Location = {
     longitude?: string | number;
   };
 };
-
-
-

--- a/statusboard/src/utils/utils.ts
+++ b/statusboard/src/utils/utils.ts
@@ -1,4 +1,7 @@
 import { Bounds, latLng } from 'leaflet';
+
+import { SortByFn, Row, IdType } from 'react-table';
+
 import { Brigade, Project } from './types';
 
 export type ActiveThresholdsKeys = 'all time' | 'year' | 'month' | 'week';
@@ -164,3 +167,51 @@ export function getTopicsFromProjects(projects?: Project[]) {
     .sort((a, b) => b[1] - a[1])
     .map((topicAndCount) => topicAndCount[0]);
 }
+
+function periodToNumber(period: string) {
+  if (period === 'week') {
+    return 0;
+  }
+  if (period === 'month') {
+    return 1;
+  }
+  if (period === 'year') {
+    return 2;
+  }
+  if (period === 'over_a_year') {
+    return 3;
+  }
+  return 99;
+}
+
+export const customStringSort: SortByFn<Project> = (
+  rowA: Row<Project>,
+  rowB: Row<Project>,
+  id: IdType<Project>,
+  desc?: boolean
+): number => {
+  const rowAValue: string = rowA.values[id] ?? '';
+  const rowBValue: string = rowB.values[id] ?? '';
+
+  const valueA: string = String(rowAValue).toLowerCase();
+  const valueB: string = String(rowBValue).toLowerCase();
+  if (desc) {
+    return valueA.localeCompare(valueB) > 0 ? 1 : -1;
+  }
+  return valueB.localeCompare(valueA) > 0 ? -1 : 1;
+};
+
+export const lastPushSort: SortByFn<Project> = (
+  rowA: Row<Project>,
+  rowB: Row<Project>,
+  id: IdType<Project>,
+  desc?: boolean
+): number => {
+  // need to convert week, month to 1, 2, ..
+  const d1: number = periodToNumber(rowA.values[id]);
+  const d2: number = periodToNumber(rowB.values[id]);
+  if (desc) {
+    return d1 - d2 > 0 ? 1 : -1;
+  }
+  return d2 - d1 > 0 ? -1 : 1;
+};


### PR DESCRIPTION
Fixes #151
 
Sorting is now case-insensitive and defaults to sort by project.
Doing this, however, surfaced an odd annoyance — there are two deprecated projects by CodeNamu in Seoul that begin with a hyphen, so they appear first in the list, even if the Seoul pin isn't visible (maybe on larger screens than I have Seoul is visible). Anyway, the easiest fix was to add an ask for the user's location and center the pin there. (We can also discuss if we also want to zoom in on the user's location or if we still want to show mostly the whole U.S.)

As I'm thinking about it another option would be to hide old projects by default on the map page, as we do on the main projects page....